### PR TITLE
fix(es5): stray arrow fn in hot transform now es5 function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,6 @@ exports.default = function (_ref2) {
     return {
       // find:
       //    export default ....
-
       ExportDefaultDeclaration: function ExportDefaultDeclaration(path) {
         if (path.__hmrWrapped) return;
 
@@ -278,7 +277,7 @@ var addImport = exports.addImport = function addImport(node) {
 };
 
 var addHotAccept = function addHotAccept(node) {
-  var acceptCall = t.callExpression(t.memberExpression(t.identifier('module.hot'), t.identifier('accept')), [t.identifier('(err) => {err && console.error(`Can not accept module: ` + err.message)}')]);
+  var acceptCall = t.callExpression(t.memberExpression(t.identifier('module.hot'), t.identifier('accept')), [t.identifier('function(err) {err && console.error(\'Can not accept module: \' + err.message)}')]);
   var statement = t.ifStatement(t.identifier('(typeof module === "object" && module.hot) && !(typeof global === "object" && global.noCycleHmr)'), t.expressionStatement(acceptCall));
   node.body.unshift(statement);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export const addImport =
 const addHotAccept = (node) => {
   const acceptCall = t.callExpression(
     t.memberExpression(t.identifier('module.hot'), t.identifier('accept')),
-    [t.identifier('(err) => {err && console.error(`Can not accept module: ` + err.message)}')]
+    [t.identifier('function(err) {err && console.error(\'Can not accept module: \' + err.message)}')]
   )
   const statement = t.ifStatement(
     t.identifier('(typeof module === "object" && module.hot) && !(typeof global === "object" && global.noCycleHmr)'),

--- a/test/fixtures/insert-hot-accept/transformed.js
+++ b/test/fixtures/insert-hot-accept/transformed.js
@@ -1,4 +1,4 @@
-if ((typeof module === "object" && module.hot) && !(typeof global === "object" && global.noCycleHmr)) module.hot.accept((err) => {err && console.error(`Can not accept module: ` + err.message)});
+if ((typeof module === "object" && module.hot) && !(typeof global === "object" && global.noCycleHmr)) module.hot.accept(function(err) {err && console.error('Can not accept module: ' + err.message)});
 import { Observable } from 'rx';
 import { Imported } from 'Imporeted';
 


### PR DESCRIPTION
This delightful software sadly fails in iOS Safari, and probably in other browsers that do not natively support arrow functions. Babel transpiles all arrow functions it detects to ES5, but it can't detect an arrow function that is hardcoded as a string, for insertion into transpiled client files. This was the symptom:

![image](https://cloud.githubusercontent.com/assets/1643758/17650964/49c26118-6221-11e6-8116-9d8d7db70824.png)

Safari cannot understand the arrow syntax.

[This](https://github.com/whitecolor/babel-plugin-cycle-hmr/blob/master/src/index.js#L51) was the culprit:

``` js
const acceptCall = t.callExpression(
    t.memberExpression(t.identifier('module.hot'), t.identifier('accept')),
    [t.identifier('(err) => {err && console.error(`Can not accept module: ` + err.message)}')]
  )
```

Since this code passes the arrow function as a string, the Babel process that builds this plugin itself fails to transpile it. You can see it emitted as a plain arrow function in the resulting [lib/index.js](https://github.com/whitecolor/babel-plugin-cycle-hmr/blob/master/lib/index.js#L281) file.

This PR simply replaces it with an ES5 function and updates the associated test. No functionality change occurs, except it works in iOS Safari now.
